### PR TITLE
Remove final

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,6 @@ This repo contains opinionated versions of the Laravel stubs. The most notable c
 - none of the model attributes are guarded
 - use return type hints where possible
 - most docblocks have been removed
-- `final` has been added to most classes
 - `declare(strict_types=1);` added to most files
 
 ## Installation

--- a/stubs/cast.inbound.stub
+++ b/stubs/cast.inbound.stub
@@ -6,7 +6,7 @@ namespace {{ namespace }};
 
 use Illuminate\Contracts\Database\Eloquent\CastsInboundAttributes;
 
-final class {{ class }} implements CastsInboundAttributes
+class {{ class }} implements CastsInboundAttributes
 {
     public function set($model, string $key, $value, array $attributes)
     {

--- a/stubs/cast.stub
+++ b/stubs/cast.stub
@@ -6,7 +6,7 @@ namespace {{ namespace }};
 
 use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
 
-final class {{ class }} implements CastsAttributes
+class {{ class }} implements CastsAttributes
 {
     public function get($model, string $key, $value, array $attributes)
     {

--- a/stubs/channel.stub
+++ b/stubs/channel.stub
@@ -6,7 +6,7 @@ namespace {{ namespace }};
 
 use {{ namespacedUserModel }};
 
-final class {{ class }}
+class {{ class }}
 {
     public function __construct()
     {

--- a/stubs/console.stub
+++ b/stubs/console.stub
@@ -6,7 +6,7 @@ namespace {{ namespace }};
 
 use Illuminate\Console\Command;
 
-final class {{ class }} extends Command
+class {{ class }} extends Command
 {
     protected $signature = '{{ command }}';
 

--- a/stubs/controller.api.stub
+++ b/stubs/controller.api.stub
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 use Illuminate\Http\Request;
 
-final class {{ class }}
+class {{ class }}
 {
     public function index()
     {

--- a/stubs/controller.invokable.stub
+++ b/stubs/controller.invokable.stub
@@ -6,7 +6,7 @@ namespace {{ namespace }};
 
 use Illuminate\Http\Request;
 
-final class {{ class }}
+class {{ class }}
 {
     public function __invoke(Request $request)
     {

--- a/stubs/controller.model.api.stub
+++ b/stubs/controller.model.api.stub
@@ -7,7 +7,7 @@ namespace {{ namespace }};
 use {{ namespacedModel }};
 use {{ namespacedRequests }}
 
-final class {{ class }}
+class {{ class }}
 {
     public function index()
     {

--- a/stubs/controller.model.stub
+++ b/stubs/controller.model.stub
@@ -7,7 +7,7 @@ namespace {{ namespace }};
 use {{ namespacedModel }};
 use {{ namespacedRequests }}
 
-final class {{ class }}
+class {{ class }}
 {
     public function index()
     {

--- a/stubs/controller.nested.api.stub
+++ b/stubs/controller.nested.api.stub
@@ -8,7 +8,7 @@ use {{ namespacedModel }};
 use Illuminate\Http\Request;
 used {{ namespacedParentModel }};
 
-final class {{ class }}
+class {{ class }}
 {
     public function index({{ parentModel }} ${{ parentModelVariable }})
     {

--- a/stubs/controller.nested.stub
+++ b/stubs/controller.nested.stub
@@ -8,7 +8,7 @@ use {{ namespacedModel }};
 use Illuminate\Http\Request;
 use {{ namespacedParentModel }};
 
-final class {{ class }}
+class {{ class }}
 {
     public function index({{ parentModel }} ${{ parentModelVariable }})
     {

--- a/stubs/controller.plain.stub
+++ b/stubs/controller.plain.stub
@@ -4,6 +4,6 @@ declare(strict_types=1);
 
 namespace {{ namespace }};
 
-final class {{ class }}
+class {{ class }}
 {
 }

--- a/stubs/controller.stub
+++ b/stubs/controller.stub
@@ -6,7 +6,7 @@ namespace {{ namespace }};
 
 use Illuminate\Http\Request;
 
-final class {{ class }}
+class {{ class }}
 {
     public function index()
     {

--- a/stubs/event.stub
+++ b/stubs/event.stub
@@ -12,7 +12,7 @@ use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
 use Illuminate\Foundation\Events\Dispatchable;
 use Illuminate\Queue\SerializesModels;
 
-final class {{ class }}
+class {{ class }}
 {
     use Dispatchable;
     use InteractsWithSockets;

--- a/stubs/exception-render-report.stub
+++ b/stubs/exception-render-report.stub
@@ -7,7 +7,7 @@ namespace {{ namespace }};
 use Exception;
 use Illuminate\Http\Request;
 
-final class {{ class }} extends Exception
+class {{ class }} extends Exception
 {
     public function render(Request $request)
     {

--- a/stubs/exception-render.stub
+++ b/stubs/exception-render.stub
@@ -7,7 +7,7 @@ namespace {{ namespace }};
 use Exception;
 use Illuminate\Http\Request;
 
-final class {{ class }} extends Exception
+class {{ class }} extends Exception
 {
     public function render(Request $request)
     {

--- a/stubs/exception-report.stub
+++ b/stubs/exception-report.stub
@@ -6,7 +6,7 @@ namespace {{ namespace }};
 
 use Exception;
 
-final class {{ class }} extends Exception
+class {{ class }} extends Exception
 {
     public function report(): ?bool
     {

--- a/stubs/exception.stub
+++ b/stubs/exception.stub
@@ -6,6 +6,6 @@ namespace {{ namespace }};
 
 use Exception;
 
-final class {{ class }} extends Exception
+class {{ class }} extends Exception
 {
 }

--- a/stubs/factory.stub
+++ b/stubs/factory.stub
@@ -10,7 +10,7 @@ use Illuminate\Database\Eloquent\Factories\Factory;
 /**
  * @extends \Illuminate\Database\Eloquent\Factories\Factory<\{{ namespacedModel }}>
  */
-final class {{ factory}}Factory extends Factory
+class {{ factory}}Factory extends Factory
 {
     protected $model = {{ model }}::class;
 

--- a/stubs/job.queued.stub
+++ b/stubs/job.queued.stub
@@ -11,7 +11,7 @@ use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
 
-final class {{ class }} implements ShouldQueue
+class {{ class }} implements ShouldQueue
 {
     use Dispatchable;
     use InteractsWithQueue;

--- a/stubs/job.stub
+++ b/stubs/job.stub
@@ -6,7 +6,7 @@ namespace {{ namespace }};
 
 use Illuminate\Foundation\Bus\Dispatchable;
 
-final class {{ class }}
+class {{ class }}
 {
     use Dispatchable;
 

--- a/stubs/livewire.inline.stub
+++ b/stubs/livewire.inline.stub
@@ -6,7 +6,7 @@ namespace [namespace];
 
 use Livewire\Component;
 
-final class [class] extends Component
+class [class] extends Component
 {
     public function render(): string
     {

--- a/stubs/livewire.stub
+++ b/stubs/livewire.stub
@@ -7,7 +7,7 @@ namespace [namespace];
 use Illuminate\Contracts\View\View;
 use Livewire\Component;
 
-final class [class] extends Component
+class [class] extends Component
 {
     public function render(): View
     {

--- a/stubs/mail.stub
+++ b/stubs/mail.stub
@@ -11,7 +11,7 @@ use Illuminate\Mail\Mailables\Content;
 use Illuminate\Mail\Mailables\Envelope;
 use Illuminate\Queue\SerializesModels;
 
-final class {{ class }} extends Mailable
+class {{ class }} extends Mailable
 {
     use Queueable;
     use SerializesModels;

--- a/stubs/markdown-mail.stub
+++ b/stubs/markdown-mail.stub
@@ -11,7 +11,7 @@ use Illuminate\Mail\Mailables\Content;
 use Illuminate\Mail\Mailables\Envelope;
 use Illuminate\Queue\SerializesModels;
 
-final class {{ class }} extends Mailable
+class {{ class }} extends Mailable
 {
     use Queueable;
     use SerializesModels;

--- a/stubs/markdown-notification.stub
+++ b/stubs/markdown-notification.stub
@@ -9,7 +9,7 @@ use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;
 
-final class {{ class }} extends Notification
+class {{ class }} extends Notification
 {
     use Queueable;
 

--- a/stubs/middleware.stub
+++ b/stubs/middleware.stub
@@ -7,7 +7,7 @@ namespace {{ namespace }};
 use Closure;
 use Illuminate\Http\Request;
 
-final class {{ class }}
+class {{ class }}
 {
     public function handle(Request $request, Closure $next)
     {

--- a/stubs/model.morph-pivot.stub
+++ b/stubs/model.morph-pivot.stub
@@ -6,6 +6,6 @@ namespace {{ namespace }};
 
 use Illuminate\Database\Eloquent\Relations\MorphPivot;
 
-final class {{ class }} extends MorphPivot
+class {{ class }} extends MorphPivot
 {
 }

--- a/stubs/model.pivot.stub
+++ b/stubs/model.pivot.stub
@@ -6,6 +6,6 @@ namespace {{ namespace }};
 
 use Illuminate\Database\Eloquent\Relations\Pivot;
 
-final class {{ class }} extends Pivot
+class {{ class }} extends Pivot
 {
 }

--- a/stubs/model.stub
+++ b/stubs/model.stub
@@ -7,7 +7,7 @@ namespace {{ namespace }};
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
-final class {{ class }} extends Model
+class {{ class }} extends Model
 {
     use HasFactory;
 

--- a/stubs/notification.stub
+++ b/stubs/notification.stub
@@ -9,7 +9,7 @@ use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;
 
-final class {{ class }} extends Notification
+class {{ class }} extends Notification
 {
     use Queueable;
 

--- a/stubs/observer.plain.stub
+++ b/stubs/observer.plain.stub
@@ -4,6 +4,6 @@ declare(strict_types=1);
 
 namespace {{ namespace }};
 
-final class {{ class }}
+class {{ class }}
 {
 }

--- a/stubs/observer.stub
+++ b/stubs/observer.stub
@@ -6,7 +6,7 @@ namespace {{ namespace }};
 
 use {{ namespacedModel }};
 
-final class {{ class }}
+class {{ class }}
 {
     public function created({{ model }} ${{ modelVariable }})
     {

--- a/stubs/policy.plain.stub
+++ b/stubs/policy.plain.stub
@@ -7,7 +7,7 @@ namespace {{ namespace }};
 use {{ namespacedUserModel }};
 use Illuminate\Auth\Access\HandlesAuthorization;
 
-final class {{ class }}
+class {{ class }}
 {
     use HandlesAuthorization;
 }

--- a/stubs/policy.stub
+++ b/stubs/policy.stub
@@ -8,7 +8,7 @@ use {{ namespacedModel }};
 use {{ namespacedUserModel }};
 use Illuminate\Auth\Access\HandlesAuthorization;
 
-final class {{ class }}
+class {{ class }}
 {
     use HandlesAuthorization;
 }

--- a/stubs/provider.stub
+++ b/stubs/provider.stub
@@ -6,7 +6,7 @@ namespace {{ namespace }};
 
 use Illuminate\Support\ServiceProvider;
 
-final class {{ class }} extends ServiceProvider
+class {{ class }} extends ServiceProvider
 {
     public function register(): void
     {

--- a/stubs/request.stub
+++ b/stubs/request.stub
@@ -6,7 +6,7 @@ namespace {{ namespace }};
 
 use Illuminate\Foundation\Http\FormRequest;
 
-final class {{ class }} extends FormRequest
+class {{ class }} extends FormRequest
 {
     public function authorize(): bool
     {

--- a/stubs/resource-collection.stub
+++ b/stubs/resource-collection.stub
@@ -6,7 +6,7 @@ namespace {{ namespace }};
 
 use Illuminate\Http\Resources\Json\ResourceCollection;
 
-final class {{ class }} extends ResourceCollection
+class {{ class }} extends ResourceCollection
 {
     public function toArray($request)
     {

--- a/stubs/resource.stub
+++ b/stubs/resource.stub
@@ -6,7 +6,7 @@ namespace {{ namespace }};
 
 use Illuminate\Http\Resources\Json\JsonResource;
 
-final class {{ class }} extends JsonResource
+class {{ class }} extends JsonResource
 {
     public function toArray($request)
     {

--- a/stubs/rule.invokable.implicit.stub
+++ b/stubs/rule.invokable.implicit.stub
@@ -6,7 +6,7 @@ namespace {{ namespace }};
 
 use Illuminate\Contracts\Validation\InvokableRule;
 
-final class {{ class }} implements InvokableRule
+class {{ class }} implements InvokableRule
 {
     public bool $implicit = true;
 

--- a/stubs/rule.invokable.stub
+++ b/stubs/rule.invokable.stub
@@ -6,7 +6,7 @@ namespace {{ namespace }};
 
 use Illuminate\Contracts\Validation\InvokableRule;
 
-final class {{ class }} implements InvokableRule
+class {{ class }} implements InvokableRule
 {
     public function __invoke($attribute, $value, $fail)
     {

--- a/stubs/rule.stub
+++ b/stubs/rule.stub
@@ -6,7 +6,7 @@ namespace {{ namespace }};
 
 use Illuminate\Contracts\Validation\InvokableRule;
 
-final class {{ class }} implements InvokableRule
+class {{ class }} implements InvokableRule
 {
     public function __invoke($attribute, $value, $fail)
     {

--- a/stubs/scope.stub
+++ b/stubs/scope.stub
@@ -8,7 +8,7 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Scope;
 
-final class {{ class }} implements Scope
+class {{ class }} implements Scope
 {
     public function apply(Builder $builder, Model $model): void
     {

--- a/stubs/seeder.stub
+++ b/stubs/seeder.stub
@@ -7,7 +7,7 @@ namespace {{ namespace }};
 use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
 
-final class {{ class }} extends Seeder
+class {{ class }} extends Seeder
 {
     public function run(): void
     {

--- a/stubs/view-component.stub
+++ b/stubs/view-component.stub
@@ -6,7 +6,7 @@ namespace {{ namespace }};
 
 use Illuminate\View\Component;
 
-final class {{ class }} extends Component
+class {{ class }} extends Component
 {
     public function __construct()
     {


### PR DESCRIPTION
Remove the `final` keyword from classes. Was previously my preference to mark classes as final, but not anymore.
